### PR TITLE
feat: redux devtools support

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -1,5 +1,6 @@
 import { Domain, CompositeName } from 'effector';
 import * as inspector from './inspector';
+import * as devtools from './redux-devtools';
 
 function createName(composite: CompositeName): string {
   return composite.path.slice(1).join('/');
@@ -21,6 +22,7 @@ export function applyLog(domain: Domain) {
         'color: gray;',
         fileName,
       );
+      devtools.log('EVENT', name, payload);
     });
   });
 
@@ -28,6 +30,8 @@ export function applyLog(domain: Domain) {
     const name = createName(store.compositeName);
     const fileName = (store as any).defaultConfig?.loc?.file ?? ' ';
     inspector.addStore(store);
+
+    devtools.updateStore(name, store.defaultState);
 
     store.updates.watch((value) => {
       console.log(
@@ -39,6 +43,7 @@ export function applyLog(domain: Domain) {
         'color: gray',
         fileName,
       );
+      devtools.log('STORE', name, value);
     });
   });
 
@@ -56,6 +61,7 @@ export function applyLog(domain: Domain) {
         'color: gray',
         fileName,
       );
+      devtools.log('EFFECT', name, parameters);
     });
 
     effect.done.watch(({ params, result }) => {
@@ -69,6 +75,7 @@ export function applyLog(domain: Domain) {
         'color: gray',
         fileName,
       );
+      devtools.log('EFFECT DONE', name, params, result);
     });
 
     effect.fail.watch(({ params, error }) => {
@@ -82,6 +89,7 @@ export function applyLog(domain: Domain) {
         'color: gray',
         fileName,
       );
+      devtools.log('EFFECT FAIL', name, params, error);
     });
   });
 

--- a/src/redux-devtools.ts
+++ b/src/redux-devtools.ts
@@ -1,0 +1,18 @@
+// @ts-ignore
+const reduxDevTools = typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__;
+let stores: any = {};
+
+export const updateStore = (name: string, state: any) => {
+  if (reduxDevTools) {
+    stores[name] = state;
+  }
+}
+
+export const log = (type: string, name: string, payload: any, result?: any) => {
+  if (reduxDevTools) {
+    if (type === 'STORE') {
+      updateStore(name, payload);
+    }
+    reduxDevTools.send({ type: `${type} ${name}`, payload, result }, stores);
+  }
+}


### PR DESCRIPTION
Add support of [Redux Devtools extension](https://github.com/zalmoxisus/redux-devtools-extension).

[Extenstion integration blog post](https://medium.com/@zalmoxis/redux-devtools-without-redux-or-how-to-have-a-predictable-state-with-any-architecture-61c5f5a7716f)

